### PR TITLE
migration for release of polars 0.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to `polars_excel_writer` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-01-20
+
+- move to polars 0.36.2
+
 ## [0.5.0] - 2024-01-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ repository = "https://github.com/jmcnamara/polars_excel_writer"
 keywords = ["polars", "excel", "xlsx"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 
 [dependencies]
 chrono = "0.4.31"
 polars = {version = "0.36.2", features = ["lazy"]}
-rust_xlsxwriter = {version = "0.61.1", features = ["chrono", "polars"]}
+rust_xlsxwriter = {git = "https://github.com/GuillaumePressiat/rust_xlsxwriter", version = "0.61.1", features = ["chrono", "polars"]}
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.31"
 polars = {version = "0.36.2", features = ["lazy"]}
-rust_xlsxwriter = {git = "https://github.com/GuillaumePressiat/rust_xlsxwriter", version = "0.61.1", features = ["chrono", "polars"]}
+rust_xlsxwriter = {git = "https://github.com/jmcnamara/rust_xlsxwriter", version = "0.61.1", features = ["chrono", "polars"]}
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.31"
-polars = {version = "0.35.4", features = ["lazy"]}
-rust_xlsxwriter = {version = "0.61.0", features = ["chrono", "polars"]}
+polars = {version = "0.36.2", features = ["lazy"]}
+rust_xlsxwriter = {version = "0.61.1", features = ["chrono", "polars"]}
 
 
 [dev-dependencies]

--- a/src/xlsx_writer.rs
+++ b/src/xlsx_writer.rs
@@ -1349,7 +1349,7 @@ impl PolarsXlsxWriter {
                             &options.float_format,
                         )?;
                     }
-                    AnyValue::Utf8(value) => {
+                    AnyValue::String(value) => {
                         worksheet.write_string(row_num, col_num, value)?;
                     }
                     AnyValue::Boolean(value) => {


### PR DESCRIPTION
Hi,

Thanks for your work.

Don't know if it will help a bit.

Small changes to adapt this work for polars 0.36.2


Biggest change is to replace Utf8 to String in src/xlsx_writer.rs

tests are ok and exports in xlsx works fine for me using `polars_excel_writer::ExcelWriter`  


First I've changed the version in rust_xlsxwriter [here](https://github.com/GuillaumePressiat/rust_xlsxwriter/blob/main/Cargo.toml#L18) too but haven't pull request it since it's really a minor change.